### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Terraform module to create and manage Amazon Managed Grafana
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -49,6 +49,7 @@ Terraform module to create and manage Amazon Managed Grafana
 | <a name="input_organization_role_name"></a> [organization\_role\_name](#input\_organization\_role\_name) | The role name that the workspace uses to access resources through Amazon Organizations | `string` | `null` | no |
 | <a name="input_organizational_units"></a> [organizational\_units](#input\_organizational\_units) | The Amazon Organizations organizational units that the workspace is authorized to use data sources from | `list(string)` | `[]` | no |
 | <a name="input_permission_type"></a> [permission\_type](#input\_permission\_type) | The permission type of the workspace. If `SERVICE_MANAGED` is specified, the IAM roles and IAM policy attachments are generated automatically. If `CUSTOMER_MANAGED` is specified, the IAM roles and IAM policy attachments will not be created | `string` | `"CUSTOMER_MANAGED"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_role_association"></a> [role\_association](#input\_role\_association) | List of user/group IDs to assocaite to a role | <pre>list(object({<br/>    group_ids = optional(list(string))<br/>    role      = string<br/>    user_ids  = optional(list(string))<br/>  }))</pre> | `[]` | no |
 | <a name="input_saml_configuration"></a> [saml\_configuration](#input\_saml\_configuration) | The SAML configuration for the workspace | <pre>object({<br/>    admin_role_values       = optional(list(string))<br/>    allowed_organizations   = optional(list(string))<br/>    editor_role_values      = list(string)<br/>    email_assertion         = optional(string)<br/>    groups_assertion        = optional(string)<br/>    idp_metadata_url        = optional(string)<br/>    idp_metadata_xml        = optional(string)<br/>    login_assertion         = optional(string)<br/>    login_validity_duration = optional(number)<br/>    name_assertion          = optional(string)<br/>    org_assertion           = optional(string)<br/>    role_assertion          = optional(string)<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | `{}` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,10 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v1.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of 6.0 to support the `region` parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
+- Default Grafana version has been updated from `10.4` to `12.4`

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_grafana_role_association" "default" {
   for_each = { for i, v in var.role_association : v.role => v }
 
+  region       = var.region
   group_ids    = each.value.group_ids
   role         = each.value.role
   user_ids     = each.value.user_ids
@@ -10,6 +11,7 @@ resource "aws_grafana_role_association" "default" {
 }
 
 resource "aws_grafana_workspace" "default" {
+  region                    = var.region
   account_access_type       = var.account_access_type
   authentication_providers  = var.authentication_providers
   configuration             = var.configuration
@@ -46,6 +48,7 @@ resource "aws_grafana_workspace" "default" {
 resource "aws_grafana_workspace_api_key" "default" {
   for_each = { for i, v in var.workspace_api_key : v.name => v }
 
+  region          = var.region
   key_name        = each.value.name
   key_role        = each.value.role
   seconds_to_live = each.value.seconds_to_live
@@ -55,6 +58,7 @@ resource "aws_grafana_workspace_api_key" "default" {
 resource "aws_grafana_workspace_saml_configuration" "default" {
   count = var.saml_configuration != null ? 1 : 0
 
+  region                  = var.region
   admin_role_values       = var.saml_configuration.admin_role_values
   allowed_organizations   = var.saml_configuration.allowed_organizations
   editor_role_values      = var.saml_configuration.editor_role_values

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,12 @@ variable "permission_type" {
   }
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "role_association" {
   type = list(object({
     group_ids = optional(list(string))

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
⚠️ **This introduces a breaking change as it requires at least v6 of the AWS provider.** ⚠️

## :hammer_and_wrench: Summary

This pull request updates the MCAF User Terraform module to support explicit region configuration and upgrades the AWS provider version. The main focus is on allowing users to specify the AWS region for all related resources which improves multi-region compatibility and control. The AWS provider version is updated to the latest major version.

**Region configuration improvements:** 

* Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for the SSM Parameters. If omitted, the default provider region is used.


## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.
