### PR TITLE
fix: Fix iam configuration of datasources

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Terraform module to create and manage Amazon Managed Grafana
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 

--- a/iam.tf
+++ b/iam.tf
@@ -2,12 +2,14 @@ locals {
   create_iam_role = var.iam_role_arn == null && var.permission_type == "CUSTOMER_MANAGED" ? true : false
 
   data_source_iam_policies = {
-    ATHENA     = "arn:aws:iam::aws:policy/service-role/AmazonGrafanaAthenaAccess"
-    CLOUDWATCH = "arn:aws:iam::aws:policy/service-role/AmazonGrafanaCloudWatchAccess"
-    REDSHIFT   = "arn:aws:iam::aws:policy/service-role/AmazonGrafanaRedshiftAccess"
-    SITEWISE   = "arn:aws:iam::aws:policy/service-role/AWSIoTSiteWiseReadOnlyAccess"
-    TIMESTREAM = "arn:aws:iam::aws:policy/AmazonTimestreamReadOnlyAccess"
-    XRAY       = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
+    AMAZON_OPENSEARCH_SERVICE = null
+    ATHENA                    = "arn:aws:iam::aws:policy/service-role/AmazonGrafanaAthenaAccess"
+    CLOUDWATCH                = "arn:aws:iam::aws:policy/service-role/AmazonGrafanaCloudWatchAccess"
+    PROMETHEUS                = null
+    REDSHIFT                  = "arn:aws:iam::aws:policy/service-role/AmazonGrafanaRedshiftAccess"
+    SITEWISE                  = "arn:aws:iam::aws:policy/service-role/AWSIoTSiteWiseReadOnlyAccess"
+    TIMESTREAM                = "arn:aws:iam::aws:policy/AmazonTimestreamReadOnlyAccess"
+    XRAY                      = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
   }
 }
 
@@ -73,7 +75,7 @@ module "execution_role" {
 
   name                  = "GrafanaExecution-${var.name}"
   create_policy         = true
-  policy_arns           = [for i, v in var.data_sources : local.data_source_iam_policies[v]]
+  policy_arns           = compact([for i, v in var.data_sources : local.data_source_iam_policies[v]])
   principal_type        = "Service"
   principal_identifiers = ["grafana.amazonaws.com"]
   role_policy           = data.aws_iam_policy_document.default[0].json

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Fix error when no default policy exists for datasource. Currently there is an error:

```
Error: Invalid index
on .terraform/modules/radar_support_grafana/iam.tf line 76, in module "execution_role":
  policy_arns           = [for i, v in var.data_sources : local.data_source_iam_policies[v]]
local.data_source_iam_policies is object with 6 attributes
The given key does not identify an element in this collection value.
```

Simply add items with `null` and then remove the nulls from the list

## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
